### PR TITLE
ensure rocksdb started at backend init

### DIFF
--- a/src/mnesia_rocksdb.app.src
+++ b/src/mnesia_rocksdb.app.src
@@ -8,5 +8,5 @@
   {registered, []},
   {mod, {mnesia_rocksdb_app, []}},
   {env, []},
-  {applications, [kernel, stdlib]}
+  {applications, [kernel, stdlib, rocksdb]}
  ]}.

--- a/src/mnesia_rocksdb.erl
+++ b/src/mnesia_rocksdb.erl
@@ -253,7 +253,7 @@ i_show_table(I, Move, Limit) ->
 
 init_backend() ->
     stick_rocksdb_dir(),
-    application:start(mnesia_rocksdb),
+    application:ensure_all_started(mnesia_rocksdb),
     ok.
 
 %% Prevent reloading of modules in rocksdb itself during runtime, since it


### PR DESCRIPTION
In the mnesia_eleveldb implementation, no automatic runtime dependency to eleveldb was coded. This was because there were competing implementations, each with slightly different performance characteristics.

For this repos, I suggest we automatically start rocksdb.