### PR TITLE
Fix application dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps,
  [
   {sext, "1.8.0"},
-  {rocksdb,"1.6.0"}
+  {rocksdb, {git, "git@github.com:k32/erlang-rocksdb.git", {tag, "1.7.0-k32"}}}
  ]}.
 
 {profiles,

--- a/src/mnesia_rocksdb.app.src
+++ b/src/mnesia_rocksdb.app.src
@@ -8,5 +8,5 @@
   {registered, []},
   {mod, {mnesia_rocksdb_app, []}},
   {env, []},
-  {applications, [kernel, stdlib, rocksdb]}
+  {applications, [kernel, stdlib, rocksdb, sext]}
  ]}.


### PR DESCRIPTION
Add sext as a runtime dependency, otherwise relx will not include it to the release.