### PR TITLE
Ignore certain mnesia_dumper close_table requests

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,11 +1,4 @@
 %% -*- erlang-mode -*-
-case os:getenv("ERLANG_ROCKSDB_OPTS") of
-    false ->
-        true = os:putenv("ERLANG_ROCKSDB_OPTS", "-DWITH_BUNDLE_LZ4=ON");
-    _ ->
-        %% If manually set, we assume it's throught through
-        skip
-end.
 case os:getenv("DEBUG") of
     "true" ->
 	Opts = proplists:get_value(erl_opts, CONFIG, []),

--- a/src/mnesia_rocksdb.erl
+++ b/src/mnesia_rocksdb.erl
@@ -162,7 +162,6 @@
             , type
             , status
             , on_error
-            , loaders = []
             }).
 
 -type data_tab() :: atom().
@@ -452,8 +451,13 @@ close_table(Alias, Tab) ->
         error ->
             ok;
         _ ->
-            ok = mnesia_rocksdb_admin:prep_close(Alias, Tab),
-            close_table_(Alias, Tab)
+            case get(mnesia_dumper_dets) of
+                undefined ->
+                    ok = mnesia_rocksdb_admin:prep_close(Alias, Tab),
+                    close_table_(Alias, Tab);
+                _ ->
+                    ok
+            end
     end.
 
 close_table_(Alias, Tab) ->
@@ -799,7 +803,7 @@ handle_call({create_table, Tab, Props}, _From,
 handle_call({load_table, _LoadReason, Props}, {Pid,_},
             #st{alias = Alias, tab = Tab} = St) ->
     {ok, _Ref} = mnesia_rocksdb_admin:load_table(Alias, Tab, Props),
-    {reply, ok, St#st{status = active, loaders = [Pid|St#st.loaders]}};
+    {reply, ok, St#st{status = active}};
 handle_call({write_info, Key, Value}, _From, #st{tab = Tab} = St) ->
     mrdb:write_info(get_ref(Tab), Key, Value),
     {reply, ok, St};
@@ -824,14 +828,9 @@ handle_call({delete, Key}, _From, St) ->
 handle_call({match_delete, Pat}, _From, #st{tab = Tab} = St) ->
     Res = mrdb:match_delete(get_ref(Tab), Pat),
     {reply, Res, St};
-handle_call(close_table, {Pid,_}, #st{alias = Alias, tab = Tab, loaders = Ls} = St) ->
-    case Ls -- [Pid] of
-        [] ->
-            _ = mnesia_rocksdb_admin:close_table(Alias, Tab),
-            {reply, ok, St#st{status = undefined, loaders = []}};
-        Ls1 ->
-            {reply, ok, St#st{loaders = Ls1}}
-    end;
+handle_call(close_table, {Pid,_}, #st{alias = Alias, tab = Tab} = St) ->
+    _ = mnesia_rocksdb_admin:close_table(Alias, Tab),
+    {reply, ok, St#st{status = undefined}};
 handle_call(delete_table, _From, #st{alias = Alias, tab = Tab} = St) ->
     ok = mnesia_rocksdb_admin:delete_table(Alias, Tab),
     {stop, normal, ok, St#st{status = undefined}}.

--- a/src/mnesia_rocksdb.erl
+++ b/src/mnesia_rocksdb.erl
@@ -346,14 +346,11 @@ semantics(_Alias, index_fun) -> fun index_f/4;
 semantics(_Alias, _) -> undefined.
 
 is_index_consistent(Alias, {Tab, index, PosInfo}) ->
-    case info(Alias, Tab, {index_consistent, PosInfo}) of
-        true -> true;
-        _ -> false
-    end.
+    mnesia_rocksdb_admin:read_info(Alias, Tab, {index_consistent, PosInfo}, false).
 
-index_is_consistent(_Alias, {Tab, index, PosInfo}, Bool)
+index_is_consistent(Alias, {Tab, index, PosInfo}, Bool)
   when is_boolean(Bool) ->
-    mrdb:write_info(Tab, {index_consistent, PosInfo}, Bool).
+    mnesia_rocksdb_admin:write_info(Alias, Tab, {index_consistent, PosInfo}, Bool).
 
 
 %% PRIVATE FUN

--- a/src/mnesia_rocksdb_admin.erl
+++ b/src/mnesia_rocksdb_admin.erl
@@ -510,12 +510,17 @@ intersection(A, B) ->
 
 -spec handle_req(alias(), req(), backend(), st()) -> gen_server_reply().
 handle_req(Alias, {create_table, Name, Props}, Backend, St) ->
-    case create_trec(Alias, Name, Props, Backend, St) of
-        {ok, NewCf} ->
-            St1 = update_cf(Alias, Name, NewCf, St),
-            {reply, {ok, NewCf}, St1};
-        {error, _} = Error ->
-            {reply, Error, St}
+    case find_cf(Alias, Name, Backend, St) of
+        {ok, TRec} ->
+            {reply, {ok, TRec}, St};
+        error ->
+            case create_trec(Alias, Name, Props, Backend, St) of
+                {ok, NewCf} ->
+                    St1 = update_cf(Alias, Name, NewCf, St),
+                    {reply, {ok, NewCf}, St1};
+                {error, _} = Error ->
+                    {reply, Error, St}
+            end
     end;
 handle_req(Alias, {load_table, Name, Props}, Backend, St) ->
     try


### PR DESCRIPTION
In certain circumstances, mnesia reads the transaction log, creates tables and writes data to tables.
When doing so on an external copy using `disc_only_copies` semantics, it expects to open and then close the table, just like it does with dets. With mnesia_rocksdb, the tables are opened once, and should remain open, and responding to the `close_table` request from the dumper causes unexpected behavior.

To avoid this, `mnesia_rocksdb` checks for the presence of `mnesia_dumper_dets` state in the process dictionary, and if found, simply returns ok without doing anything.