### PR TITLE
Don't try to release dummy batch ref

### DIFF
--- a/src/mnesia_rocksdb.erl
+++ b/src/mnesia_rocksdb.erl
@@ -800,7 +800,7 @@ handle_call({create_table, Tab, Props}, _From,
         exit:{aborted, Error} ->
             {reply, {aborted, Error}, St}
     end;
-handle_call({load_table, _LoadReason, Props}, {Pid,_},
+handle_call({load_table, _LoadReason, Props}, _,
             #st{alias = Alias, tab = Tab} = St) ->
     {ok, _Ref} = mnesia_rocksdb_admin:load_table(Alias, Tab, Props),
     {reply, ok, St#st{status = active}};
@@ -828,7 +828,7 @@ handle_call({delete, Key}, _From, St) ->
 handle_call({match_delete, Pat}, _From, #st{tab = Tab} = St) ->
     Res = mrdb:match_delete(get_ref(Tab), Pat),
     {reply, Res, St};
-handle_call(close_table, {Pid,_}, #st{alias = Alias, tab = Tab} = St) ->
+handle_call(close_table, _, #st{alias = Alias, tab = Tab} = St) ->
     _ = mnesia_rocksdb_admin:close_table(Alias, Tab),
     {reply, ok, St#st{status = undefined}};
 handle_call(delete_table, _From, #st{alias = Alias, tab = Tab} = St) ->

--- a/src/mrdb.erl
+++ b/src/mrdb.erl
@@ -506,6 +506,8 @@ rdb_write_batch_and_pop(BatchRef, C) ->
         pop_ctxt()
     end.
 
+rdb_release_batch(?BATCH_REF_DUMMY) ->
+    ok;
 rdb_release_batch(H) ->
     rocksdb:release_batch(H).
 


### PR DESCRIPTION
After having seen this crash report in the field:
```
16:13:55.643 [error] CRASH REPORT Process aec_tx_pool_gc with 0 neighbours crashed with reason: bad argument in call to rocksdb:release_batch('$mrdb_batch_ref_dummy') in mrdb:maps_foreach_/2 line 1097
```