### PR TITLE
Use erlang-rocksdb with fix for macos build issue with snappy tests

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps,
  [
   {sext, "1.8.0"},
-  {rocksdb, {git, "https://gitlab.com/seanhinde/erlang-rocksdb.git", {ref,"9ae37839"}}},
+  {rocksdb, {git, "https://gitlab.com/seanhinde/erlang-rocksdb.git", {ref,"8543fda8"}}},
   {hut, "1.3.0"}
  ]}.
 


### PR DESCRIPTION
Fix build issue when googletest library is also installed (e.g. via brew on mac m1 machine)

This PR was sponsored by the ACF