### PR TITLE
Adding/deleting indexes cleans up index metadata

### DIFF
--- a/src/mnesia_rocksdb_admin.erl
+++ b/src/mnesia_rocksdb_admin.erl
@@ -312,7 +312,7 @@ maybe_delete_standalone_info(Ref, K) ->
         #{type := standalone, vsn := 1, db_ref := DbRef} ->
             EncK = mnesia_rocksdb_lib:encode_key(K, sext),
             Key = <<?INFO_TAG, EncK/binary>>,
-            rocksb:delete(DbRef, Key, []);
+            rocksdb:delete(DbRef, Key, []);
         _ ->
             ok
     end.


### PR DESCRIPTION
See issue #43 

This PR ensures that the `index_consistent` marker is cleared when deleting an index, and - to be safe - also when a new index is created. A test suite was added, and also some index utility functions.