### PR TITLE
Run multiple OTP vsns in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       ERLANG_ROCKSDB_BUILDOPTS: "-j2"
 
 jobs:
-  - otp24
+  otp24:
       build:
         executor: aebuilder
         steps:
@@ -23,7 +23,7 @@ jobs:
           - run: make test
           - store_artifacts:
               path: _build/test/logs
-  - otp23
+  otp23:
       build:
         executor: aebuilder23
         steps:
@@ -31,3 +31,9 @@ jobs:
           - run: make test
           - store_artifacts:
               path: _build/test/logs
+
+workflows:
+  build_and_test:
+    jobs:
+      - otp23
+      - otp24

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,12 @@ version: 2.1
 executors:
   aebuilder:
     docker:
+      - image: aeternity/builder:bionic-otp24
+        user: builder
+    environment:
+      ERLANG_ROCKSDB_BUILDOPTS: "-j2"
+  aebuilder23:
+    docker:
       - image: aeternity/builder:bionic-otp23
         user: builder
     environment:
@@ -14,3 +20,12 @@ jobs:
     steps:
       - checkout
       - run: make test
+      - store_artifacts:
+          path: _build/test/logs
+  build-otp23:
+    executor: aebuilder23
+    steps:
+      - checkout
+      - run: make test
+      - store_artifacts:
+          path: _build/test/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,17 +15,19 @@ executors:
       ERLANG_ROCKSDB_BUILDOPTS: "-j2"
 
 jobs:
-  build:
-    executor: aebuilder
-    steps:
-      - checkout
-      - run: make test
-      - store_artifacts:
-          path: _build/test/logs
-  build-otp23:
-    executor: aebuilder23
-    steps:
-      - checkout
-      - run: make test
-      - store_artifacts:
-          path: _build/test/logs
+  - otp24
+      build:
+        executor: aebuilder
+        steps:
+          - checkout
+          - run: make test
+          - store_artifacts:
+              path: _build/test/logs
+  - otp23
+      build:
+        executor: aebuilder23
+        steps:
+          - checkout
+          - run: make test
+          - store_artifacts:
+              path: _build/test/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,21 +16,19 @@ executors:
 
 jobs:
   otp24:
-      build:
-        executor: aebuilder
-        steps:
-          - checkout
-          - run: make test
-          - store_artifacts:
-              path: _build/test/logs
+    executor: aebuilder
+    steps:
+      - checkout
+      - run: make test
+      - store_artifacts:
+          path: _build/test/logs
   otp23:
-      build:
-        executor: aebuilder23
-        steps:
-          - checkout
-          - run: make test
-          - store_artifacts:
-              path: _build/test/logs
+    executor: aebuilder23
+    steps:
+      - checkout
+      - run: make test
+      - store_artifacts:
+          path: _build/test/logs
 
 workflows:
   build_and_test:


### PR DESCRIPTION
Outcomes seem to differ depending on OTP version. Run different versions in CI and keep artifacts for debugging.