### PR TITLE
Fix wrong index preparation in mrdb:index_read_/3

### DIFF
--- a/src/mrdb.erl
+++ b/src/mrdb.erl
@@ -938,7 +938,7 @@ index_read_(#{name := Main, semantics := Sem} = Ref, Val, Ix) ->
             _ when is_atom(Ix) ->
                 {attr_pos(Ix, Ref), ordered};
             {_} ->
-                Ix;
+                {Ix, ordered};
             _ when is_integer(Ix) ->
                 {Ix, ordered}
         end,


### PR DESCRIPTION
In the case when index is of type {_}, index is returned as is instead of putting it into a tuple {Ix, ordered}.

I attached a module with an example that will trigger the error and below I show behavior before and after the patch.
[key6.erl.txt](https://github.com/user-attachments/files/16556974/key6.erl.txt)

Rename key6.erl.txt to key6.erl, add to the path and compile, thereafter:

(rock@bang)28> rr(key6).
(rock@bang)30> #cgh{}.
#cgh{key = undefined,val = undefined}
(rock@bang)31> E1 = #cgh{key = {n1, "u1vgrjkh",{ecgi,238,6,213020,50},3}, val = ok}.
#cgh{key = {n1,"u1vgrjkh",{ecgi,238,6,213020,50},3},
     val = ok}
(rock@bang)32> mnesia:dirty_write(E1).
ok
(rock@bang)33> Index1 = list_to_binary([atom_to_binary(n1), list_to_binary(lists:sublist("u1vgrjkh", 6))]).
<<"n1u1vgrj">>
(rock@bang)34> mrdb:index_read(cgh, Index1, {k6}).
** exception exit: {aborted,{bad_type,#cgh{key = index,val = {k6}}}}
     in function  mnesia:abort/1 (mnesia.erl, line 362)
     in call from mrdb:ensure_ref/1 (~/projects/erlang/github/mnesia_rocksdb/src/mrdb.erl, line 609)
     in call from mrdb:index_read_/3 (~/projects/erlang/github/mnesia_rocksdb/src/mrdb.erl, line 945)
(rock@bang)35> mrdb:read(cgh, {n1, "u1vgrjkh",{ecgi,238,6,213020,50},3}).
[#cgh{key = {n1,"u1vgrjkh",{ecgi,238,6,213020,50},3},
      val = ok}]

---After patch----

(rock@bang)41> mrdb:index_read(cgh, Index1, {k6}).
[#cgh{key = {n1,"u1vgrjkh",{ecgi,238,6,213020,50},3},
      val = ok}]

And your example is still working properly after the patch, here comes a modified version with rocksdb_copies table:

(rock@bang)42> mnesia:create_table(j, [{rocksdb_copies, [node()]},{index, [{words}]}]).
{atomic,ok}


(rock@bang)45> mnesia:dirty_write({j,<<"one two">>, [<<"three">>, <<"four">>]}).
(<0.370.0>) call words:words_f(j,{words},{j,<<"one two">>,[<<"three">>,<<"four">>]})
(<0.370.0>) returned from words:words_f/3 -> [<<"one">>,<<"two">>,<<"three">>,
                                              <<"four">>]
(<0.370.0>) call words:words_f(j,{words},{j,<<"one two">>,[<<"three">>,<<"four">>]})
(<0.370.0>) returned from words:words_f/3 -> [<<"one">>,<<"two">>,<<"three">>,
                                              <<"four">>]
ok
(rock@bang)46> mnesia:dirty_index_read(j, <<"one">>, {words}).
(<0.370.0>) call words:words_f(j,{words},{j,<<"one two">>,[<<"three">>,<<"four">>]})
(<0.370.0>) returned from words:words_f/3 -> [<<"one">>,<<"two">>,<<"three">>,
                                              <<"four">>]
[{j,<<"one two">>,[<<"three">>,<<"four">>]}]


(rock@bang)47> mrdb:index_read(j, <<"one">>, {words}).
[{j,<<"one two">>,[<<"three">>,<<"four">>]}]




