### PR TITLE
Use emqx fork of erlang-rocksdb

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps,
  [
   {sext, "1.8.0"},
-  {rocksdb, {git, "https://gitlab.com/barrel-db/erlang-rocksdb.git", {tag,"1.8.0"}}},
+  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {tag,"1.8.0-emqx-6"}}},
   {hut, "1.4.0"}
  ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.2.0",
 [{<<"hut">>,{pkg,<<"hut">>,<<"1.4.0">>},0},
  {<<"rocksdb">>,
-  {git,"https://gitlab.com/barrel-db/erlang-rocksdb.git",
-       {ref,"fced5f637de7991c5948e28414ba3790b0476c4b"}},
+  {git,"https://github.com/emqx/erlang-rocksdb.git",
+       {ref,"1f02f720b91fb53f9535f68548c31280b345d029"}},
   0},
  {<<"sext">>,{pkg,<<"sext">>,<<"1.8.0">>},0}]}.
 [


### PR DESCRIPTION
The barreldb repo has not been touched in quite a while and uses a version of rocksdb that doesn't compile on newer systems (see e.g. https://github.com/conan-io/conan-center-index/issues/21048). The EMQX fork is actively maintained (https://github.com/emqx/erlang-rocksdb). Tested on Ubuntu 24.
