### PR TITLE
Use latest version of emqx fork with compilation fix

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps,
  [
   {sext, "1.8.0"},
-  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {tag,"1.8.0-emqx-6"}}},
+  {rocksdb, {git, "https://github.com/aeternity/erlang-rocksdb.git", {ref,"79bab7c6b6"}}},
   {hut, "1.4.0"}
  ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps,
  [
   {sext, "1.8.0"},
-  {rocksdb, {git, "https://github.com/aeternity/erlang-rocksdb.git", {ref,"79bab7c6b6"}}},
+  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {ref,"d695c6e"}}},
   {hut, "1.4.0"}
  ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.2.0",
 [{<<"hut">>,{pkg,<<"hut">>,<<"1.4.0">>},0},
  {<<"rocksdb">>,
-  {git,"https://github.com/aeternity/erlang-rocksdb.git",
-       {ref,"79bab7c6b693bf7016490c28987d0b12a6b0dae9"}},
+  {git,"https://github.com/emqx/erlang-rocksdb.git",
+       {ref,"d695c6ee9dd27bfe492ed4e24c72ad20ab0d770b"}},
   0},
  {<<"sext">>,{pkg,<<"sext">>,<<"1.8.0">>},0}]}.
 [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.2.0",
 [{<<"hut">>,{pkg,<<"hut">>,<<"1.4.0">>},0},
  {<<"rocksdb">>,
-  {git,"https://github.com/emqx/erlang-rocksdb.git",
-       {ref,"1f02f720b91fb53f9535f68548c31280b345d029"}},
+  {git,"https://github.com/aeternity/erlang-rocksdb.git",
+       {ref,"79bab7c6b693bf7016490c28987d0b12a6b0dae9"}},
   0},
  {<<"sext">>,{pkg,<<"sext">>,<<"1.8.0">>},0}]}.
 [


### PR DESCRIPTION
The EMQX fork of erlang-rocksdb had lost the ERLANG_ROCKSDB_OPTS compilation setting, and could not be built against a dynamic rocksdb library. See https://github.com/emqx/erlang-rocksdb/pull/35 for details. This also makes it build with RocksDB 8. Since this has been merged upstream, we do not need to point to Aeternity's fork of the erlang-rocksdb repo.
