### PR TITLE
Support custom cfopts passed as a part of [user_properties, rocksdb_opts]

### DIFF
--- a/src/rdb_type_extractor.erl
+++ b/src/rdb_type_extractor.erl
@@ -1,0 +1,41 @@
+-module(rdb_type_extractor).
+
+-export([extract/2]).
+
+-spec extract(Module, TypeSpecTarget) -> Result when
+    Module          :: module(),
+    TypeSpecTarget  :: atom(),
+    Result          :: [atom()].
+
+extract(Module, TypeSpecTarget) ->
+    case beam_lib:chunks(code:which(Module), [abstract_code]) of
+        {ok, {_Module, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
+            TypeForms = lists:filter(fun(AstForm) -> is_target_type(TypeSpecTarget, AstForm) end, Forms),
+            case TypeForms of
+                [Form] ->
+                    extract_keys(TypeSpecTarget, Form);
+                _ ->
+                    error(target_type_not_found)
+            end;
+        _ ->
+            error(abstract_code_not_found)
+    end.
+
+-spec is_target_type(Target, AstForm) -> Result when
+    Target  :: atom(),
+    AstForm :: tuple(),
+    Result  :: boolean().
+
+is_target_type(Target, {attribute, _, type, {Target, _, _}}) -> true;
+is_target_type(_Target, _AstForm) -> false.
+
+-spec extract_keys(Target, AstForm) -> Result when
+    Target  :: atom(),
+    AstForm :: tuple(),
+    Result  :: [atom()].
+
+extract_keys(Target, {attribute, _, type, {Target, {type, _, list, [{type, _, union, Tuples }]},[]}}) ->
+    lists:flatmap(fun
+		({type, _, tuple, [{atom, _, Key}, _Type]}) -> [Key];
+		(_) -> []
+	end, Tuples).


### PR DESCRIPTION
This PR is enabling ability to configure `cf_options` on per table basis.

For back-compatibility  and for do not introducing new nested structures, `cf_options` can be passed just together with `db_options`: 
```
mnesia:create_table(foo, [{rocksdb_copies, [node()]},
                          ...
                          {user_properties,
                              [{rocksdb_opts, 
                                  [
                                      {max_open_files, 100},                  % db_options property
                                      {num_levels, 10},                            % cf_options property
                                      {block_based_table_options, [     % cf_options property
                                           {cache_index_and_filter_blocks, true}
                                      ]}
                                  ]
                              }]
                          }])

```

Then based on available keys in type  `rocksdb:db_options()` && `rocksdb:cf_options()` we split it and pass it to the right places.