### PR TITLE
proposal: support custom cfopts passed as a part of `user_properties -> rocksdb_opts` (revised)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,8 @@
  [
   {sext, "1.8.0"},
   {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {ref,"d695c6e"}}},
-  {hut, "1.4.0"}
+  {hut, "1.4.0"},
+  {parse_trans, "3.4.2"}
  ]}.
 
 {xref_checks, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,6 @@
 {"1.2.0",
 [{<<"hut">>,{pkg,<<"hut">>,<<"1.4.0">>},0},
+ {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.4.2">>},0},
  {<<"rocksdb">>,
   {git,"https://github.com/emqx/erlang-rocksdb.git",
        {ref,"d695c6ee9dd27bfe492ed4e24c72ad20ab0d770b"}},
@@ -8,8 +9,10 @@
 [
 {pkg_hash,[
  {<<"hut">>, <<"7A1238EC00F95C9EC75412587EE11AC652ECA308A7F4B8CC9629746D579D6CF0">>},
+ {<<"parse_trans">>, <<"C352DDC1A0D5E54F9B1654D45F9C432EEF76F9CEA371C55DDFF769EF688FDB74">>},
  {<<"sext">>, <<"90A95B889F5C781B70BBCF44278B763148E313C376B60D87CE664CB1C1DD29B5">>}]},
 {pkg_hash_ext,[
  {<<"hut">>, <<"7AF8704B9BAE98A336F70D9560FC3C97F15665265FA603DBD05352E63D6EBB03">>},
+ {<<"parse_trans">>, <<"4C25347DE3B7C35732D32E69AB43D1CEEE0BEAE3F3B3ADE1B59CBD3DD224D9CA">>},
  {<<"sext">>, <<"BC6016CB8690BAF677EACACFE6E7CADFEC8DC7E286CBBED762F6CD55B0678E73">>}]}
 ].

--- a/src/mnesia_rocksdb_admin.erl
+++ b/src/mnesia_rocksdb_admin.erl
@@ -1499,7 +1499,7 @@ open_db_(MP, Alias, Opts, CFs0, CreateIfMissing) ->
                     {merge_operator, erlang_merge_operator}
                 ],
                 Opts,
-                ?open_opts_allowed
+                rdb_type_extractor:open_opts_allowed()
             ),
             log_invalid_opts(Opts),
             OpenRes = mnesia_rocksdb_lib:open_rocksdb(MP, OpenOpts, CFs),
@@ -1514,7 +1514,7 @@ open_db_(MP, Alias, Opts, CFs0, CreateIfMissing) ->
     end.
 
 log_invalid_opts(Opts) ->
-    Combined = ?open_opts_allowed ++ ?cf_opts_allowed,
+    Combined = rdb_type_extractor:open_opts_allowed() ++ rdb_type_extractor:cf_opts_allowed(),
     case lists:filter(fun({Key, _Value}) -> lists:member(Key, Combined) == false end, Opts) of
         [] ->
             ok;
@@ -1561,7 +1561,7 @@ cfs(CFs, Opts) ->
     [{"default", CfOpts}] ++ lists:flatmap(fun(Tab) -> admin_cfs(Tab, CfOpts) end, CFs).
 
 cfopts(Opts) ->
-    filter_opts([{merge_operator, erlang_merge_operator}], Opts, ?cf_opts_allowed).
+    filter_opts([{merge_operator, erlang_merge_operator}], Opts, rdb_type_extractor:cf_opts_allowed()).
 
 admin_cfs(Tab, CFOpts) when is_atom(Tab) -> [ {tab_to_cf_name(Tab), CFOpts} ];
 admin_cfs({_, _, _} = T, CFOpts)         -> [ {tab_to_cf_name(T), CFOpts} ];

--- a/src/mnesia_rocksdb_admin.erl
+++ b/src/mnesia_rocksdb_admin.erl
@@ -93,9 +93,6 @@
 
 -define(PT_KEY, {mnesia_rocksdb, meta}).
 
--define(cf_opts_allowed, rdb_type_extractor:extract(rocksdb, cf_options)).
--define(open_opts_allowed, rdb_type_extractor:extract(rocksdb, db_options)).
-
 -spec ensure_started() -> ok.
 ensure_started() ->
     case whereis(?MODULE) of

--- a/src/mnesia_rocksdb_admin.erl
+++ b/src/mnesia_rocksdb_admin.erl
@@ -1516,13 +1516,13 @@ log_invalid_opts(Opts) ->
         [] ->
             ok;
         NonEmptyList ->
-            ?log(warning, "The following options will be ingored as they are not supported in erlang's rocksdb:options(): ~p", [NonEmptyList])
+            ?log(warning, "The following options will be ignored as they are not supported in erlang's rocksdb:options(): ~p", [NonEmptyList])
     end.
 
-% filter and remove dublicates.
+% filter and remove duplicates.
 filter_opts(Defaults, Opts, Allowed) ->
     Filtered = lists:filter(fun({Key, _Value}) -> lists:member(Key, Allowed) end, Defaults ++ Opts),
-    % de-dublicate and override defaults
+    % de-duplicates and override defaults
     lists:foldl(fun
         ({Key, Value}, Acc) ->
             [{Key, Value} | lists:keydelete(Key, 1, Acc)]

--- a/src/rdb_type_extractor.erl
+++ b/src/rdb_type_extractor.erl
@@ -1,0 +1,41 @@
+-module(rdb_type_extractor).
+
+-export([extract/2]).
+
+-spec extract(Module, TypeSpecTarget) -> Result when
+    Module          :: module(),
+    TypeSpecTarget  :: atom(),
+    Result          :: [atom()].
+
+extract(Module, TypeSpecTarget) ->
+    case beam_lib:chunks(code:which(Module), [abstract_code]) of
+        {ok, {_Module, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
+            TypeForms = lists:filter(fun(AstForm) -> is_target_type(TypeSpecTarget, AstForm) end, Forms),
+            case TypeForms of
+                [Form] ->
+                    extract_keys(TypeSpecTarget, Form);
+                _ ->
+                    error(target_type_not_found)
+            end;
+        _ ->
+            error(abstract_code_not_found)
+    end.
+
+-spec is_target_type(Target, AstForm) -> Result when
+    Target  :: atom(),
+    AstForm :: tuple(),
+    Result  :: boolean().
+
+is_target_type(Target, {attribute, _, type, {Target, _, _}}) -> true;
+is_target_type(_Target, _AstForm) -> false.
+
+-spec extract_keys(Target, AstForm) -> Result when
+    Target  :: atom(),
+    AstForm :: tuple(),
+    Result  :: [atom()].
+
+extract_keys(Target, {attribute, _, type, {Target, {type, _, list, [{type, _, union, Tuples }]},[]}}) ->
+    lists:flatmap(fun
+		({type, _, tuple, [{atom, _, Key}, _Type]}) -> [Key];
+		(_) -> []
+	end, Tuples).

--- a/src/rdb_type_extractor.erl
+++ b/src/rdb_type_extractor.erl
@@ -1,6 +1,11 @@
 -module(rdb_type_extractor).
 
--export([extract/2]).
+-compile({parse_transform, ct_expand}).
+
+-export([cf_opts_allowed/0, open_opts_allowed/0, extract/2]).
+
+cf_opts_allowed() -> ct_expand:term(extract(rocksdb, cf_options)).
+open_opts_allowed() -> ct_expand:term(extract(rocksdb, db_options)).
 
 -spec extract(Module, TypeSpecTarget) -> Result when
     Module          :: module(),


### PR DESCRIPTION
This PR proposing approach for enable ability to configure `cf_options` on per table basis.
It's still missing tests, so if we confirm that approach is okay, I will add tests as well.

so,

For back-compatibility and for do not introduce new nested structures, the idea is to pass `cf_options` just together with `rocksdb_opts`:

```
mnesia:create_table(foo, [{rocksdb_copies, [node()]},
                          ...
                          {user_properties,
                              [{rocksdb_opts, 
                                  [
                                      {max_open_files, 100},                  % db_options property
                                      {num_levels, 10},                            % cf_options property
                                      {block_based_table_options, [     % cf_options property
                                           {cache_index_and_filter_blocks, true}
                                      ]}
                                  ]
                              }]
                          }])
```

Then, based on the available keys in `rocksdb:db_options()` and `rocksdb:cf_options()` split them and pass them to the appropriate places. 

For do not hardcode list of supported options, we just parse original `@type cf_options()` & `@type db_options()`from erlang's `rocksdb` library.

P.S.:

a side discovery is that when we use pure column families tables, there is no way to pass `db_options` (open DB options) even if we place it in tables `user_properties -> rocksdb_opts`. This is because we open the RocksDB instance only once - when we initialize the `admin` table (whose options are currently not configurable). As a result, the `admin`'s table `db_options` applies to all tables in the column family case.

I would be keen to volunteer and additionally implement configurable `admin`'s `db_options`, but let's figure out first, are we okay with proposed solution or not.