### PR TITLE
Pick correct open/cfs options after restart for standalone tables

### DIFF
--- a/src/mnesia_rocksdb_admin.erl
+++ b/src/mnesia_rocksdb_admin.erl
@@ -421,7 +421,7 @@ maybe_load_admin_db({Alias, Opts}, #st{backends = Bs} = St) ->
 
 try_load_admin_db(Alias, AliasOpts, #st{ backends = Bs
                                        , default_opts = DefaultOpts} = St) ->
-    case load_admin_db(Alias, AliasOpts ++ DefaultOpts) of
+    case load_admin_db(Alias, AliasOpts ++ DefaultOpts, St) of
         {ok, #{cf_info := CfI0, mountpoint := MP} = AdminDb} ->
             %% We need to store the persistent ref explicitly here,
             %% since mnesia knows nothing of our admin table.
@@ -1131,7 +1131,7 @@ create_table_as_standalone_(Alias, Name, Exists, MP, TRec, St) ->
 do_open_standalone(CreateIfMissing, Alias, Name, Exists, MP, TRec0,
                    #st{standalone = Ts} = St) ->
     Opts = rocksdb_opts_from_trec(TRec0),
-    case open_db_(MP, Alias, Opts, [], CreateIfMissing) of
+    case open_db_(MP, Alias, Opts, [], CreateIfMissing, Name, St) of
         {ok, #{ cf_info := CfI }} ->
             DbRec = maps:get({ext,Alias,"default"}, CfI),
             CfNames = maps:keys(CfI),
@@ -1474,30 +1474,22 @@ do_delete_table(Alias, Name, Backend, #st{} = St) ->
             {error, not_found}
     end.
 
-load_admin_db(Alias, Opts) ->
+load_admin_db(Alias, Opts, St) ->
     DbName = {admin, Alias},
-    open_db(DbName, Alias, Opts, [DbName], true).
+    open_db(DbName, Alias, Opts, [DbName], true, St).
 
-open_db(DbName, Alias, Opts, CFs, CreateIfMissing) ->
+open_db(DbName, Alias, Opts, CFs, CreateIfMissing, St) ->
     MP = mnesia_rocksdb_lib:data_mountpoint(DbName),
-    open_db_(MP, Alias, Opts, CFs, CreateIfMissing).
+    open_db_(MP, Alias, Opts, CFs, CreateIfMissing, DbName, St).
 
-open_db_(MP, Alias, Opts, CFs0, CreateIfMissing) ->
+open_db_(MP, Alias, Opts, CFs0, CreateIfMissing, DbName, #st{backends = Backends} = St) ->
     Acc0 = #{ mountpoint => MP },
     case filelib:is_dir(MP) of
         false when CreateIfMissing ->
             %% not yet created
             CFs = cfs(CFs0, Opts),
             file:make_dir(MP),
-            OpenOpts = filter_opts(
-                [
-                    {create_if_missing, true},
-                    {create_missing_column_families, true},
-                    {merge_operator, erlang_merge_operator}
-                ],
-                Opts,
-                rdb_type_extractor:open_opts_allowed()
-            ),
+            OpenOpts = open_opts(Opts),
             log_invalid_opts(Opts),
             OpenRes = mnesia_rocksdb_lib:open_rocksdb(MP, OpenOpts, CFs),
             map_cfs(OpenRes, CFs, Alias, Acc0);
@@ -1505,9 +1497,21 @@ open_db_(MP, Alias, Opts, CFs0, CreateIfMissing) ->
             {error, enoent};
         true ->
             %% Assumption: even an old rocksdb database file will have at least "default"
-            {ok,CFs} = rocksdb:list_column_families(MP, Opts),
-            CFs1 = [{CF,[]} || CF <- CFs], %% TODO: this really needs more checking
-            map_cfs(rocksdb_open(MP, Opts, CFs1), CFs1, Alias, Acc0)
+            {ok, CFs} = rocksdb:list_column_families(MP, Opts),
+            CFsWithOpts = case map_size(Backends) of
+                0 ->
+                    [{CF,[]} || CF <- CFs];
+                _ ->
+                    {ok, Trec} = find_cf(Alias, DbName, maps:get(Alias, Backends), St),
+                    StoredOpts = rocksdb_opts_from_trec(Trec),
+                    [{CF, cfopts(StoredOpts)} || CF <- CFs]
+            end,
+            map_cfs(
+              rocksdb_open(MP, open_opts(Opts), CFsWithOpts),
+              CFsWithOpts,
+              Alias,
+              Acc0
+            )
     end.
 
 log_invalid_opts(Opts) ->
@@ -1559,6 +1563,18 @@ cfs(CFs, Opts) ->
 
 cfopts(Opts) ->
     filter_opts([{merge_operator, erlang_merge_operator}], Opts, rdb_type_extractor:cf_opts_allowed()).
+
+open_opts(Opts) ->
+    filter_opts(
+        [
+            {create_if_missing, true},
+            {create_missing_column_families, true},
+            {merge_operator, erlang_merge_operator}
+        ],
+        Opts,
+        rdb_type_extractor:open_opts_allowed()
+    ).
+
 
 admin_cfs(Tab, CFOpts) when is_atom(Tab) -> [ {tab_to_cf_name(Tab), CFOpts} ];
 admin_cfs({_, _, _} = T, CFOpts)         -> [ {tab_to_cf_name(T), CFOpts} ];

--- a/src/mnesia_rocksdb_lib.erl
+++ b/src/mnesia_rocksdb_lib.erl
@@ -125,7 +125,7 @@ check_value_encoding({value, E} = V, [_, _]) when E==term; E==raw; E==sext -> V;
 check_value_encoding({object, E} = V, _) when E==term; E==raw; E==sext -> V;
 check_value_encoding(term, As) -> {val_encoding_type(As), term};
 check_value_encoding(sext, As) -> {val_encoding_type(As), sext};
-check_value_encoding(E, _) -> 
+check_value_encoding(E, _) ->
     throw({error, {invalid_value_encoding, E}}).
 
 val_encoding_type(Attrs) ->
@@ -141,11 +141,11 @@ valid_obj_type(#{encoding := Enc}, Obj) ->
         {{binary, _}, _} ->
             is_binary(element(2, Obj));
         {{_, {value, binary}}, {_, _, V}} ->
-            is_binary(V); 
+            is_binary(V);
         _ ->
             %% No restrictions on object type
             %% unless key and/or value typed to binary
-            true 
+            true
     end.
 
 valid_key_type(#{encoding := Enc}, Key) ->
@@ -202,7 +202,7 @@ encode_val(Val) ->
     encode(Val, term).
 
 encode_val(Val, Enc) when is_atom(Enc) ->
-    encode(Val, Enc); 
+    encode(Val, Enc);
 encode_val(_, #{name := {_,index,_}}) ->
     <<>>;
 encode_val(Val, #{encoding := {_, Enc0}, attr_pos := AP}) ->
@@ -306,6 +306,7 @@ open_db(MPd, Opts, CFs, RetriesLeft, _) ->
                     {error, Reason}
             end;
         {error, Reason} ->
+            ?log(error, "Can't open_optimistic_transaction_db with reason ~p",[Reason]),
             {error, Reason}
     end.
 


### PR DESCRIPTION
This adding routine for picking-up column family options after re-opening DB.

In previous implementation we completely ignored opts when the table exists, and always passed `[]` as cfoptions even for "default" column family.

In current implementation - we are fetching it from State's trec and passing it correctly down till `rocsdb:open_optimistic_transaction_db`

p.s: picking opts currently works only for standalone created tables.