### PR TITLE
upgrade rocksdb dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps,
  [
   {sext, "1.8.0"},
-  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {ref,"d695c6e"}}},
+  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {ref,"b0e76717"}}},
   {hut, "1.4.0"},
   {parse_trans, "3.4.2"}
  ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.4.2">>},0},
  {<<"rocksdb">>,
   {git,"https://github.com/emqx/erlang-rocksdb.git",
-       {ref,"d695c6ee9dd27bfe492ed4e24c72ad20ab0d770b"}},
+       {ref,"b0e767172483b01f5bd46fd06b2604e14e78bd42"}},
   0},
  {<<"sext">>,{pkg,<<"sext">>,<<"1.8.0">>},0}]}.
 [


### PR DESCRIPTION
The rocksdb dependency lags a bit, and makes this project not work with cmake 4. Since cmake 4 is the default now via Brew on macos, it might break for a few people. 

I updated the dependency, and ran `rebar3 eunit` without mistakes. 