### PR TITLE
Upgrade the version of emqx/erlang-rocksdb

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {deps,
  [
   {sext, "1.8.0"},
-  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {ref,"d695c6e"}}},
+  {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb.git", {tag, "1.8.0-emqx-10"}}},
   {hut, "1.4.0"},
   {parse_trans, "3.4.2"}
  ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.4.2">>},0},
  {<<"rocksdb">>,
   {git,"https://github.com/emqx/erlang-rocksdb.git",
-       {ref,"d695c6ee9dd27bfe492ed4e24c72ad20ab0d770b"}},
+       {ref,"4ea43ca3372d26e6a592d74ce9c5caa342afc5c5"}},
   0},
  {<<"sext">>,{pkg,<<"sext">>,<<"1.8.0">>},0}]}.
 [


### PR DESCRIPTION
This upgrade is needed to make it possible to compile the code using the latest version of cmake.